### PR TITLE
Make classification form a GET

### DIFF
--- a/archerycalculator/templates/classification_tables.html
+++ b/archerycalculator/templates/classification_tables.html
@@ -29,7 +29,7 @@
   </p>
 
     {% from "_formhelpers.html" import render_select2_no_search_field %}
-  <form method=post>
+  <form method=get>
     {{ render_select2_no_search_field(form.bowstyle) }}
     {{ render_select2_no_search_field(form.gender) }}
     {{ render_select2_no_search_field(form.age) }}


### PR DESCRIPTION
There's no private data being submitted here so no particular reason for it to be a POST, and it would allow direct linking to a particular version of the classificaiton table (or even just for autocomplete in the browser).

It would create a URL like https://archerycalculator.co.uk/tables/classification?bowstyle=Recurve&gender=Female&age=Under+16&discipline=outdoor

Please note I have not checked out the code or tested this at all!