### PR TITLE
Bugfix: Don't display a warning for compound bows in target

### DIFF
--- a/archerycalculator/calculator.py
+++ b/archerycalculator/calculator.py
@@ -123,7 +123,7 @@ def calculator():
                             f"Note: Treating {bowstyle} as Barebow "
                             "for the purposes of classifications."
                         )
-                    elif bowstyle.lower() in "compound barebow":
+                    elif bowstyle.lower() in ["compound barebow", "compound limited"]:
                         warning_bowstyle = (
                             f"Note: Treating {bowstyle} as Compound "
                             "for the purposes of classifications."
@@ -150,7 +150,7 @@ def calculator():
                             f"Note: Treating {bowstyle} as Barebow "
                             "for the purposes of classifications."
                         )
-                    elif bowstyle.lower() in "compound barebow":
+                    elif bowstyle.lower() in ["compound barebow", "compound limited"]:
                         warning_bowstyle = (
                             f"Note: Treating {bowstyle} as Compound "
                             "for the purposes of classifications."
@@ -484,7 +484,7 @@ def old_calculator():
                             f"Note: Treating {bowstyle} as Barebow "
                             "for the purposes of classifications."
                         )
-                    elif bowstyle.lower() == "compound barebow":
+                    elif bowstyle.lower() in ["compound barebow", "compound limited"]:
                         warning_bowstyle = (
                             f"Note: Treating {bowstyle} as Compound "
                             "for the purposes of classifications."
@@ -511,7 +511,7 @@ def old_calculator():
                             f"Note: Treating {bowstyle} as Barebow "
                             "for the purposes of classifications."
                         )
-                    elif bowstyle.lower() in "compound barebow":
+                    elif bowstyle.lower() in ["compound barebow", "compound limited"]:
                         warning_bowstyle = (
                             f"Note: Treating {bowstyle} as Compound "
                             "for the purposes of classifications."


### PR DESCRIPTION
Bugfix: Don't display a warning for compound bows in target classific…ations, only compound limited and compound barebow.

Because of simple pattern matching warning was displayed for anything containing "compound".

Now explicitly check for compound limited or barebow.