### PR TITLE
Remove secret key. Not a security issue

### DIFF
--- a/archerycalculator/__init__.py
+++ b/archerycalculator/__init__.py
@@ -34,8 +34,7 @@ def create_app(test_config=None):
     """
     app = Flask(__name__, instance_relative_config=True)
     app.config.from_mapping(
-        SECRET_KEY="dev",
-        DATABASE=os.path.join(app.instance_path, "archerycalculator.sqlite"),
+        DATABASE=os.path.join(app.instance_path, "archerycalculator.sqlite")
     )
 
     if test_config is None:


### PR DESCRIPTION
Key was currently unused as site does not utilise 'sessions' to track users, so was redundant.
Removing here, and will reinstate following good practice for open code (not in the open repo) in future.